### PR TITLE
Add role for creating users

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -2,3 +2,8 @@
 - src: https://github.com/coderefinery/gitlab-runner.git
   scm: git
   path: roles
+
+- src: https://github.com/CSCfi/ansible-role-users.git
+  scm: git
+  path: roles
+  version: "v1.8.0"

--- a/site.yml
+++ b/site.yml
@@ -38,4 +38,5 @@
 
 - hosts: runner
   roles:
+    - ansible-role-users
     - gitlab-runner


### PR DESCRIPTION
To make the runner VM more usable by multiple admins, add a role for
creating users in requirements.yaml and add this role for the runner VM.