### PR TITLE
add support for host keys and single daemon container

### DIFF
--- a/deprovision.yml
+++ b/deprovision.yml
@@ -2,13 +2,12 @@
 - hosts: runner
   gather_facts: no
   ignore_errors: yes
+  become: yes
   tasks:
     - name: unregister runners
       shell: >
-        docker exec gitlab-runner-{{ item.RUNNER_NAME }}
-        gitlab-ci-multi-runner unregister -n {{ item.RUNNER_NAME }}
-      with_items: "{{ runner_configs }}"
-      when: item.state == "started"
+        docker exec gitlab-multirunner
+        gitlab-ci-multi-runner unregister --all-runners
 
 - hosts: localhost
   connection: local

--- a/files/gitlab-runner-stack.yml
+++ b/files/gitlab-runner-stack.yml
@@ -34,8 +34,39 @@ parameters:
     description: >
       How big the volume attached to the runner VM should be.
     type: string
+  runner_ssh_key_rsa_private:
+    description: >
+      Preconfigured RSA host private key
+    type: string
+    default: ''
+  runner_ssh_key_rsa_public:
+    description: >
+      Preconfigured RSA host public key
+    type: string
+    default: ''
+  runner_ssh_key_ecdsa_private:
+    description: >
+      Preconfigured ECDSA host private key
+    type: string
+    default: ''
+  runner_ssh_key_ecdsa_public:
+    description: >
+      Preconfigured ECDSA host public key
+    type: string
+    default: ''
 
 resources:
+  cloud_config_ssh_keys:
+    # this resource demonstrates multiple cloud-config resources
+    # with a merge_how strategy
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        ssh_keys:
+          rsa_private: { get_param: runner_ssh_key_rsa_private }
+          rsa_public: { get_param: runner_ssh_key_rsa_public }
+          ecdsa_private: { get_param: runner_ssh_key_ecdsa_private }
+          ecdsa_public: { get_param: runner_ssh_key_ecdsa_public }
 
   runner_vm:
     type: OS::Nova::Server
@@ -51,6 +82,9 @@ resources:
       key_name: { get_param: key_name }
       security_groups:
         - { get_resource: secgroup_runner_vm }
+      user_data_format: RAW
+      user_data:
+        get_resource: cloud_config_ssh_keys
 
   secgroup_runner_vm:
     type: OS::Neutron::SecurityGroup

--- a/site.yml
+++ b/site.yml
@@ -17,6 +17,10 @@
           key_name: "{{ key_name }}"
           secgroup_runner_vm_rules: "{{ secgroup_runner_vm_rules }}"
           volume_runner_vm_size: "{{ volume_runner_vm_size }}"
+          runner_ssh_key_rsa_private: "{{ ssh_key_rsa_private|default('') }}"
+          runner_ssh_key_rsa_public: "{{ ssh_key_rsa_public|default('') }}"
+          runner_ssh_key_ecdsa_private: "{{ ssh_key_ecdsa_private|default('') }}"
+          runner_ssh_key_ecdsa_public: "{{ ssh_key_ecdsa_public|default('') }}"
     - name: Associate floating IP with runner VM
       os_floating_ip:
         server: "{{ env_name }}"


### PR DESCRIPTION
- heat stack now includes optional host keys in cloud-init user data
- deprovisioning adapted to unregister runners with the new
  single daemon container approach