### PR TITLE
support for rpm based installation, host keys and populating secrets

### DIFF
--- a/deprovision.yml
+++ b/deprovision.yml
@@ -2,13 +2,18 @@
 - hosts: runner
   gather_facts: no
   ignore_errors: yes
+  become: yes
   tasks:
-    - name: unregister runners
+    - name: unregister docker based runners
       shell: >
         docker exec gitlab-runner-{{ item.RUNNER_NAME }}
         gitlab-ci-multi-runner unregister -n {{ item.RUNNER_NAME }}
       with_items: "{{ runner_configs }}"
       when: item.state == "started"
+
+    - name: unregister rpm/binary based runners
+      shell: >
+        gitlab-runner unregister --all-runners
 
 - hosts: localhost
   connection: local

--- a/files/gitlab-runner-stack.yml
+++ b/files/gitlab-runner-stack.yml
@@ -34,8 +34,37 @@ parameters:
     description: >
       How big the volume attached to the runner VM should be.
     type: string
+  runner_ssh_key_rsa_private:
+    description: >
+      Preconfigured RSA host private key
+    type: string
+    default: ''
+  runner_ssh_key_rsa_public:
+    description: >
+      Preconfigured RSA host public key
+    type: string
+    default: ''
+  runner_ssh_key_ecdsa_private:
+    description: >
+      Preconfigured ECDSA host private key
+    type: string
+    default: ''
+  runner_ssh_key_ecdsa_public:
+    description: >
+      Preconfigured ECDSA host public key
+    type: string
+    default: ''
 
 resources:
+  cloud_config_ssh_keys:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        ssh_keys:
+          rsa_private: { get_param: runner_ssh_key_rsa_private }
+          rsa_public: { get_param: runner_ssh_key_rsa_public }
+          ecdsa_private: { get_param: runner_ssh_key_ecdsa_private }
+          ecdsa_public: { get_param: runner_ssh_key_ecdsa_public }
 
   runner_vm:
     type: OS::Nova::Server
@@ -51,6 +80,9 @@ resources:
       key_name: { get_param: key_name }
       security_groups:
         - { get_resource: secgroup_runner_vm }
+      user_data_format: RAW
+      user_data:
+        get_resource: cloud_config_ssh_keys
 
   secgroup_runner_vm:
     type: OS::Neutron::SecurityGroup

--- a/site.yml
+++ b/site.yml
@@ -17,6 +17,10 @@
           key_name: "{{ key_name }}"
           secgroup_runner_vm_rules: "{{ secgroup_runner_vm_rules }}"
           volume_runner_vm_size: "{{ volume_runner_vm_size }}"
+          runner_ssh_key_rsa_private: "{{ ssh_key_rsa_private|default('') }}"
+          runner_ssh_key_rsa_public: "{{ ssh_key_rsa_public|default('') }}"
+          runner_ssh_key_ecdsa_private: "{{ ssh_key_ecdsa_private|default('') }}"
+          runner_ssh_key_ecdsa_public: "{{ ssh_key_ecdsa_public|default('') }}"
     - name: Associate floating IP with runner VM
       os_floating_ip:
         server: "{{ env_name }}"
@@ -35,6 +39,23 @@
       delay: 5
       changed_when: false
       delegate_to: localhost
+
+- hosts: runner
+  become: True
+  tasks:
+    - name: create /dev/shm/secret
+      file:
+        path: /dev/shm/secret
+        state: directory
+
+    - name: initialize secrets in /dev/shm/secret
+      copy:
+        src: "{{ item.src|default('/dev/shm/secret/' + item.name) }}"
+        dest: "/dev/shm/secret/{{ item.name }}"
+        mode: "{{ item.mode|default(omit) }}"
+        owner: "{{ item.owner|default(omit) }}"
+        group: "{{ item.group|default(omit) }}"
+      with_items: "{{ runner_secrets|default([]) }}"
 
 - hosts: runner
   roles:


### PR DESCRIPTION
- heat stack now includes optional host keys in cloud-init user data
- files containing secrets can be copied automatically to runner
  host from the control host
- deprovisioning also supports unregister for rpm-based runners