### PR TITLE
Add mandatory configuration of an SSH key

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no
+ssh_args = -i /dev/shm/id_rsa_gitlab_runner -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no
 pipelining = True
 
 [defaults]

--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,16 @@
 ---
 - hosts: localhost
+  gather_facts: yes
+  connection: local
+  tasks:
+    - name: Place SSH private key on RAM disk
+      copy:
+        content: "{{ runner_vm_ssh_key }}"
+        dest: "/dev/shm/id_rsa_gitlab_runner"
+        owner: "{{ ansible_user_id }}"
+        mode: 0600
+
+- hosts: localhost
   gather_facts: no
   connection: local
   tasks:
@@ -32,7 +43,10 @@
   gather_facts: no
   tasks:
     - name: Wait for SSH to work
-      shell: ssh {{ ansible_ssh_user }}@{{ ansible_ssh_host }} 'echo success'
+      shell: >
+        ssh -i /dev/shm/id_rsa_gitlab_runner
+        {{ ansible_ssh_user }}@{{ ansible_ssh_host }}
+        'echo success'
       register: result
       until: result.stdout.find('success') != -1
       retries: 30


### PR DESCRIPTION
Make it so that the SSH private key used for connecting to the runner
instance must be configured as an Ansible variable. This way it will
always be stored in a Vault file under group_vars and the default
identity from the machine running Ansible is not used. This means that
anyone with the Vault key for decrypting the data in the Vault files
will be able to access the runner VM.