### PR TITLE
Dynamic inventory caching config in clouds.yaml

### DIFF
--- a/clouds.yaml
+++ b/clouds.yaml
@@ -1,0 +1,2 @@
+cache:
+  expiration_time: 3600


### PR DESCRIPTION
Configure dynamic inventory caching via clouds.yaml to speed things up
during configuration. Set an expiration time of 3600 seconds, i.e. 1
hour.