### PR TITLE
Allow putting secrets in multiple directories

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -43,15 +43,19 @@
 - hosts: runner
   become: True
   tasks:
-    - name: create /dev/shm/secret
+    - name: create directories for secrets
       file:
-        path: /dev/shm/secret
+        path: "{{ item.dest | dirname }}"
         state: directory
+      with_items:
+        - dest: "/dev/shm/secret/"
+        - "{{ runner_secrets|default([]) }}"
+      when: item.dest is defined
 
     - name: initialize secrets in /dev/shm/secret
       copy:
         src: "{{ item.src|default('/dev/shm/secret/' + item.name) }}"
-        dest: "/dev/shm/secret/{{ item.name }}"
+        dest: "{{ item.dest|default('/dev/shm/secret/' + item.name) }}"
         mode: "{{ item.mode|default(omit) }}"
         owner: "{{ item.owner|default(omit) }}"
         group: "{{ item.group|default(omit) }}"


### PR DESCRIPTION
Instead of only creating /dev/shm/secret, allow creation of directories
for multiple vault secrets based on the dest key of an item in the
runner_secrets list. This way we can place separate secrets for
different runners in their own directory.

Backwards compatibility is maintained through always creating
/dev/shm/secret.

Currently additional directories created should be subdirectories of an
existing directory (like /dev/shm/secret) as Ansible will not recurse to
create directories.